### PR TITLE
Keep WINDOWS_TEST_ROOTFS for gats98 package

### DIFF
--- a/garden_integration_tests_suite_test.go
+++ b/garden_integration_tests_suite_test.go
@@ -92,8 +92,12 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	rootfs, exists := os.LookupEnv("TEST_ROOTFS")
 	ExpectWithOffset(1, exists).To(BeTrue(), "Set TEST_ROOTFS Env variable")
 
-	binary, err := gexec.Build("code.cloudfoundry.org/garden-integration-tests/plugins/consume-mem")
-	Expect(err).ToNot(HaveOccurred())
+	binary := ""
+	if runtime.GOOS == "windows" {
+		var err error
+		binary, err = gexec.Build("code.cloudfoundry.org/garden-integration-tests/plugins/consume-mem")
+		Expect(err).ToNot(HaveOccurred())
+	}
 
 	limitsURI, exists := os.LookupEnv("LIMITS_TEST_URI")
 	ExpectWithOffset(1, exists).To(BeTrue(), "Set LIMITS_TEST_URI Env variable")

--- a/gats98/gats98_suite_test.go
+++ b/gats98/gats98_suite_test.go
@@ -61,9 +61,9 @@ func TestGats98(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	BeforeSuite(func() {
-		gardenRootfs, present := os.LookupEnv("TEST_ROOTFS")
+		gardenRootfs, present := os.LookupEnv("WINDOWS_TEST_ROOTFS")
 		if !present {
-			fmt.Println("Must set $TEST_ROOTFS")
+			fmt.Println("Must set $WINDOWS_TEST_ROOTFS")
 			os.Exit(1)
 		}
 		testImage = garden.ImageRef{URI: gardenRootfs}


### PR DESCRIPTION
- Skip consume-mem build on linux since we run this project in an errand and don't have go installed at runtime