### PR TITLE
With oss ci export

### DIFF
--- a/bin/test.bash
+++ b/bin/test.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+source "$CI_DIR/shared/helpers/filesystem-helpers.bash"
+filesystem_permit_device_control
+filesystem_create_loop_devices 256
+
+configure_gdn
+
+mkdir -p /var/lib/grootfs
+# shellcheck disable=SC2068
+# Double-quoting array expansion here causes ginkgo to fail
+go run github.com/onsi/ginkgo/v2/ginkgo ${@}

--- a/garden_integration_tests_suite_test.go
+++ b/garden_integration_tests_suite_test.go
@@ -89,8 +89,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		host = "10.244.0.2"
 	}
 
-	rootfs, exists := os.LookupEnv("TEST_ROOTFS")
-	ExpectWithOffset(1, exists).To(BeTrue(), "Set TEST_ROOTFS Env variable")
+	rootfs, exists := os.LookupEnv("GARDEN_TEST_ROOTFS")
+	ExpectWithOffset(1, exists).To(BeTrue(), "Set GARDEN_TEST_ROOTFS Env variable")
 
 	binary := ""
 	if runtime.GOOS == "windows" {

--- a/gats98/gats98_suite_test.go
+++ b/gats98/gats98_suite_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -61,6 +62,9 @@ func TestGats98(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	BeforeSuite(func() {
+		if runtime.GOOS != "windows" {
+			Skip("Skipping GATS98 as we are not running windows")
+		}
 		gardenRootfs, present := os.LookupEnv("WINDOWS_TEST_ROOTFS")
 		if !present {
 			fmt.Println("Must set $WINDOWS_TEST_ROOTFS")

--- a/limits_test.go
+++ b/limits_test.go
@@ -195,8 +195,8 @@ var _ = Describe("Limits", func() {
 					limits.Disk.ByteHard = limitsTestContainerImageSize + 60*1024*1024
 					limits.Disk.Scope = garden.DiskLimitScopeTotal
 				} else {
-					limits.Disk.ByteSoft = 10 * 1024 * 1024
-					limits.Disk.ByteHard = 10 * 1024 * 1024
+					limits.Disk.ByteSoft = 20 * 1024 * 1024
+					limits.Disk.ByteHard = 20 * 1024 * 1024
 					limits.Disk.Scope = garden.DiskLimitScopeTotal
 				}
 			})
@@ -210,7 +210,7 @@ var _ = Describe("Limits", func() {
 					Expect(metrics.DiskStat.TotalBytesUsed).To(BeNumerically("~", limitsTestContainerImageSize+containerStartUsage, 20*1024*1024))
 
 				} else {
-					Expect(metrics.DiskStat.TotalBytesUsed).To(BeNumerically("~", 1024*1024, 512*1024)) // base busybox is > 1 MB but less than 1.5 MB
+					Expect(metrics.DiskStat.TotalBytesUsed).To(BeNumerically("~", 4*1024*1024, 1024*1024)) // base busybox is ~4 MB
 				}
 			})
 
@@ -253,7 +253,7 @@ var _ = Describe("Limits", func() {
 						spec = garden.ProcessSpec{
 							User: "root",
 							Path: "dd",
-							Args: []string{"if=/dev/zero", "of=/root/test", "bs=1M", "count=10"},
+							Args: []string{"if=/dev/zero", "of=/root/test", "bs=1M", "count=20"},
 						}
 					}
 					exitCode, _, _ := runProcess(container, spec)

--- a/networking_test.go
+++ b/networking_test.go
@@ -3,7 +3,6 @@ package garden_integration_tests_test
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -101,12 +100,13 @@ var _ = Describe("Networking", func() {
 		tryPing := func(address string) string {
 			var output bytes.Buffer
 
+			GinkgoWriter.TeeTo(&output)
 			proc, err := container.Run(garden.ProcessSpec{
 				Path: "ping",
 				Args: []string{"-W", "2", "-c", "1", address},
 			}, garden.ProcessIO{
-				Stdout: io.MultiWriter(GinkgoWriter, &output),
-				Stderr: io.MultiWriter(GinkgoWriter, &output),
+				Stdout: GinkgoWriter,
+				Stderr: GinkgoWriter,
 			})
 			Expect(err).NotTo(HaveOccurred())
 

--- a/networking_test.go
+++ b/networking_test.go
@@ -113,9 +113,9 @@ var _ = Describe("Networking", func() {
 			pingExitCh := make(chan struct{})
 			go func(pingProc garden.Process, exitCh chan<- struct{}) {
 				defer GinkgoRecover()
+				defer close(exitCh)
 				_, err := pingProc.Wait()
 				Expect(err).NotTo(HaveOccurred())
-				close(pingExitCh)
 			}(proc, pingExitCh)
 
 			_, err = container.Run(garden.ProcessSpec{
@@ -131,6 +131,7 @@ var _ = Describe("Networking", func() {
 			case <-pingExitCh:
 				return output.String()
 			case <-time.After(time.Second * 2):
+				close(pingExitCh)
 				return "timed out after 2 seconds"
 			}
 		}

--- a/networking_test.go
+++ b/networking_test.go
@@ -118,15 +118,6 @@ var _ = Describe("Networking", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}(proc, pingExitCh)
 
-			_, err = container.Run(garden.ProcessSpec{
-				Path: "ping",
-				Args: []string{"-W", "4", "-c", "3", "8.8.8.8"},
-			}, garden.ProcessIO{
-				Stdout: GinkgoWriter,
-				Stderr: GinkgoWriter,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
 			select {
 			case <-pingExitCh:
 				return output.String()

--- a/peas_test.go
+++ b/peas_test.go
@@ -70,11 +70,10 @@ var _ = Describe("Partially shared containers (peas)", func() {
 			Skip("pending for windows")
 		}
 		stdout := runForStdout(container, garden.ProcessSpec{
-			Path:  "cat",
-			Args:  []string{"/etc/os-release"},
+			Path:  "busybox",
 			Image: peaImage,
 		})
-		Expect(stdout).To(gbytes.Say(`NAME="Alpine Linux"`))
+		Expect(stdout).To(gbytes.Say(`BusyBox v`))
 	})
 
 	Describe("pea process user and group", func() {
@@ -113,7 +112,7 @@ var _ = Describe("Partially shared containers (peas)", func() {
 					Args:  []string{"-c", "echo -n $(id -u):$(id -g); whoami"},
 					Image: peaImage,
 				})
-				Expect(stdout).To(gbytes.Say("11:0operator"))
+				Expect(stdout).To(gbytes.Say("37:37operator"))
 			})
 
 			Context("but /etc/passwd is empty", func() {

--- a/security_test.go
+++ b/security_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Security", func() {
 
 			It("cgroup filesystems are mounted as read-only", func() {
 				getCGroupMountOptions := func(mounts string) map[string]bool {
-					cgroupMountRegex := regexp.MustCompile(`.*\s/sys/fs/cgroup/[^\s]*\s([^\s]*) - cgroup cgroup *\s([^\s]*)`)
+					cgroupMountRegex := regexp.MustCompile(`.*\s/sys/fs/cgroup/[^\s]*\s([^\s]*).*cgroup cgroup *\s([^\s]*)`)
 					matches := cgroupMountRegex.FindAllStringSubmatch(mounts, -1)
 					cgroupMountOptions := make(map[string]bool)
 					for _, m := range matches {
@@ -127,11 +127,8 @@ var _ = Describe("Security", func() {
 				Expect(cgroupMountOptions).To(HaveKey("devices"))
 				Expect(cgroupMountOptions).To(HaveKey("freezer"))
 				Expect(cgroupMountOptions).To(HaveKey("perf_event"))
-
-				// TODO: re-add the "hugetlb" and "pids" cgroups to this list once we've fixed this bug:
-				// https://www.pivotaltracker.com/story/show/158623469
-				// Expect(cgroupMountOptions).To(HaveKey("pids"))
-				// Expect(cgroupMountOptions).To(HaveKey("hugetlb"))
+				Expect(cgroupMountOptions).To(HaveKey("pids"))
+				Expect(cgroupMountOptions).To(HaveKey("hugetlb"))
 			})
 		})
 


### PR DESCRIPTION
- Use GARDEN_TEST_ROOTFS instead of TEST_ROOTFS for consistency in Guardian
- Change test for busybox base image instead of alpine