### PR TITLE
Use Limits Rootfs instead of default rootfs

### DIFF
--- a/limits_test.go
+++ b/limits_test.go
@@ -486,6 +486,7 @@ var _ = Describe("Limits", func() {
 				}
 
 				limits.Pid = garden.PidLimits{Max: 50}
+				imageRef.URI = limitsTestURI
 			})
 
 			It("prevents forking of processes", func() {

--- a/security_test.go
+++ b/security_test.go
@@ -26,6 +26,9 @@ var _ = Describe("Security", func() {
 	})
 
 	Describe("PID namespace", func() {
+		BeforeEach(func() {
+			imageRef.URI = limitsTestURI
+		})
 		It("isolates processes so that only processes from inside the container are visible", func() {
 			createUser(container, "alice")
 
@@ -185,6 +188,9 @@ var _ = Describe("Security", func() {
 	})
 
 	Describe("rlimits", func() {
+		BeforeEach(func() {
+			imageRef.URI = limitsTestURI
+		})
 		It("sets requested rlimits", func() {
 			limit := uint64(4567)
 			stdout := runForStdout(container, garden.ProcessSpec{


### PR DESCRIPTION
default rootfs is now based on busybox:1.26.1, but limits rootfs is based on latest busybox