### PR TITLE
increase timeout setting for - should disappear after grace time and before timeout

### DIFF
--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -1546,7 +1546,7 @@ done
 				Eventually(func() error {
 					_, err := gardenClient.Lookup(containerHandle)
 					return err
-				}, "10s", "2s").Should(HaveOccurred())
+				}, "60s", "2s").Should(HaveOccurred())
 			}
 		})
 


### PR DESCRIPTION
increase timeout setting for - should disappear after grace time and before timeout test case.

             [FAILED] Timed out after 10.001s.  
             Expected an error to have occurred.  Got:  
                 <nil>: nil  
             In [It] at: /var/vcap/packages/gats/src/garden-integration-tests/lifecycle_test.go:1549 @ 08/14/25 03:01:05.985  