### PR TITLE
Update BusyBox to 1.37.0 to fix CVE-2022-48174

### DIFF
--- a/networking_test.go
+++ b/networking_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Networking", func() {
 
 		Context("when the rootFS doesn't contain /etc/hosts or /etc/resolv.conf", func() {
 			BeforeEach(func() {
-				imageRef.URI = "docker:///busybox#1.36.1"
+				imageRef.URI = "docker:///busybox#1.37.0"
 			})
 
 			It("can still resolve domain names because garden modifies /etc/resolv.conf", func() {


### PR DESCRIPTION
- Update networking_test.go to use busybox:1.37.0 instead of 1.36.1
- Addresses CVE-2022-48174 (stack overflow vulnerability in ash.c)